### PR TITLE
Integrate Fail2ban with Traefik for enhanced security

### DIFF
--- a/playbooks/roles/monitoring/defaults/main.yml
+++ b/playbooks/roles/monitoring/defaults/main.yml
@@ -23,6 +23,8 @@ nvidia_gpu_exporter_image: "utkuozdemir/nvidia_gpu_exporter"
 nvidia_gpu_exporter_version: "1.4.1"
 watchtower_image: "percona/watchtower"
 watchtower_version: "3"
+fail2ban_exporter_image: "crazymax/fail2ban-prometheus-exporter"
+fail2ban_exporter_version: "latest"
 ollama_metrics_dashboard_url:
   "https://raw.githubusercontent.com/NorskHelsenett/ollama-metrics/main/prometheus/dashboard.json"
 
@@ -37,6 +39,7 @@ grafana_dashboard_updates:
   - gnet_id: 23005 # Watchtower
   - gnet_id: 18077 # Unbound (Prometheus + Loki)
   - gnet_id: 14574 # NVIDIA GPU Metrics (nvidia_gpu_exporter)
+  - gnet_id: 15742 # Fail2ban Exporter (crazymax)
 
 # Alerting configuration
 # These should be overridden in group_vars or host_vars

--- a/playbooks/roles/monitoring/defaults/main.yml
+++ b/playbooks/roles/monitoring/defaults/main.yml
@@ -23,7 +23,7 @@ nvidia_gpu_exporter_image: "utkuozdemir/nvidia_gpu_exporter"
 nvidia_gpu_exporter_version: "1.4.1"
 watchtower_image: "percona/watchtower"
 watchtower_version: "3"
-fail2ban_exporter_image: "crazymax/fail2ban-prometheus-exporter"
+fail2ban_exporter_image: "registry.gitlab.com/hctrdev/fail2ban-prometheus-exporter"
 fail2ban_exporter_version: "latest"
 ollama_metrics_dashboard_url:
   "https://raw.githubusercontent.com/NorskHelsenett/ollama-metrics/main/prometheus/dashboard.json"
@@ -39,7 +39,7 @@ grafana_dashboard_updates:
   - gnet_id: 23005 # Watchtower
   - gnet_id: 18077 # Unbound (Prometheus + Loki)
   - gnet_id: 14574 # NVIDIA GPU Metrics (nvidia_gpu_exporter)
-  - gnet_id: 15742 # Fail2ban Exporter (crazymax)
+  - gnet_id: 16125 # Fail2ban
 
 # Alerting configuration
 # These should be overridden in group_vars or host_vars

--- a/playbooks/roles/monitoring/templates/docker-compose.yml
+++ b/playbooks/roles/monitoring/templates/docker-compose.yml
@@ -265,6 +265,19 @@ services:
       - backend
   {% endif %}
 
+  fail2ban-exporter:
+    labels:
+      - com.centurylinklabs.watchtower.enable=true
+    image: "{{ fail2ban_exporter_image }}:{{ fail2ban_exporter_version }}"
+    command:
+      - --web.listen-address=:9191
+      - --collector.f2b.socket=/var/run/fail2ban/fail2ban.sock
+    volumes:
+      - /var/run/fail2ban/fail2ban.sock:/var/run/fail2ban/fail2ban.sock:ro
+    networks:
+      - backend
+    restart: unless-stopped
+
   autoheal: # restart container when healthcheck is ko
     labels:
       - com.centurylinklabs.watchtower.enable=true

--- a/playbooks/roles/monitoring/templates/prometheus.yml
+++ b/playbooks/roles/monitoring/templates/prometheus.yml
@@ -53,6 +53,9 @@ scrape_configs:
   - job_name: authentik
     static_configs:
       - targets: ['authentik-server-1:9300']
+  - job_name: fail2ban
+    static_configs:
+      - targets: ['fail2ban-exporter:9191']
   - job_name: ollama-metrics
     scrape_interval: 15s
     static_configs:

--- a/playbooks/roles/traefik/defaults/main.yml
+++ b/playbooks/roles/traefik/defaults/main.yml
@@ -13,3 +13,14 @@ unbound_offline_fallback_enabled: true
 unbound_compose_project_name: "traefik"
 alpine_image: "alpine"
 alpine_version: "3.23"
+
+# Access log path on the host (mounted into the container for fail2ban)
+traefik_accesslog_host_path: "/var/log/traefik"
+
+# Buffering middleware – 0 means no limit, which avoids restricting Nextcloud large-file transfers
+traefik_max_response_body_bytes: 0
+
+# Fail2ban integration
+traefik_fail2ban_maxretry: 5
+traefik_fail2ban_findtime: 600
+traefik_fail2ban_bantime: 3600

--- a/playbooks/roles/traefik/handlers/main.yml
+++ b/playbooks/roles/traefik/handlers/main.yml
@@ -6,4 +6,11 @@
     name: systemd-resolved
     state: restarted
     enabled: true
+
+- name: Restart fail2ban
+  become: true
+  ansible.builtin.systemd:
+    name: fail2ban
+    state: restarted
+    enabled: true
 ...

--- a/playbooks/roles/traefik/tasks/main.yml
+++ b/playbooks/roles/traefik/tasks/main.yml
@@ -5,6 +5,14 @@
     path: "/home/{{ ansible_user }}/home-server/stacks/traefik"
     state: directory
     mode: u=rwx,g=o=rx
+
+- name: Create Traefik access log directory
+  become: true
+  ansible.builtin.file:
+    path: "{{ traefik_accesslog_host_path }}"
+    state: directory
+    mode: u=rwx,g=rx,o=rx
+
 - name: Create traefik provisionning directories
   become: true
   ansible.builtin.file:
@@ -248,6 +256,35 @@
     build: "always"
     state: present
     project_src: /home/{{ ansible_user }}/home-server/stacks/traefik
+
+- name: Install fail2ban
+  become: true
+  ansible.builtin.package:
+    name: fail2ban
+    state: present
+
+- name: Deploy fail2ban filter for Traefik
+  become: true
+  ansible.builtin.template:
+    src: fail2ban-filter-traefik.conf.j2
+    dest: /etc/fail2ban/filter.d/traefik.conf
+    mode: u=rw,g=r,o=r
+  notify: Restart fail2ban
+
+- name: Deploy fail2ban jail for Traefik
+  become: true
+  ansible.builtin.template:
+    src: fail2ban-jail-traefik.conf.j2
+    dest: /etc/fail2ban/jail.d/traefik.conf
+    mode: u=rw,g=r,o=r
+  notify: Restart fail2ban
+
+- name: Enable and start fail2ban
+  become: true
+  ansible.builtin.systemd:
+    name: fail2ban
+    state: started
+    enabled: true
 
 - name: Check Authentik API availability
   ansible.builtin.uri:

--- a/playbooks/roles/traefik/templates/docker-compose.yml
+++ b/playbooks/roles/traefik/templates/docker-compose.yml
@@ -44,6 +44,7 @@ services:
       - --entrypoints.https.http.tls.domains[0].sans=*.{{ app_domain_name }}
       - --entrypoints.https.forwardedheaders.insecure
       - --accesslog
+      - --accesslog.filepath=/var/log/traefik/access.log
       - --log
       - --log.level=INFO
       - --api
@@ -64,6 +65,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:rw
       - traefik-public-certificates:/certificates
       - traefik-rules:/rules
+      - "{{ traefik_accesslog_host_path }}:/var/log/traefik"
 
 {% if unbound %}
   unbound:

--- a/playbooks/roles/traefik/templates/fail2ban-filter-traefik.conf.j2
+++ b/playbooks/roles/traefik/templates/fail2ban-filter-traefik.conf.j2
@@ -1,0 +1,11 @@
+[INCLUDES]
+before = common.conf
+
+[Definition]
+# Match Traefik Combined Log Format lines that result in 401 / 403 / 429 responses.
+# Format: <IP> - <user> [timestamp] "METHOD /path HTTP/x.y" STATUS bytes "referer" "ua"
+failregex = ^<HOST> -\s+\S+\s+\[.*?\]\s+"[^"]+"\s+(401|403|429)\s+\d+
+
+ignoreregex =
+
+datepattern = \[%%d/%%b/%%Y:%%H:%%M:%%S %%z\]

--- a/playbooks/roles/traefik/templates/fail2ban-jail-traefik.conf.j2
+++ b/playbooks/roles/traefik/templates/fail2ban-jail-traefik.conf.j2
@@ -1,0 +1,8 @@
+[traefik-auth]
+enabled  = true
+filter   = traefik
+logpath  = {{ traefik_accesslog_host_path }}/access.log
+maxretry = {{ traefik_fail2ban_maxretry }}
+findtime = {{ traefik_fail2ban_findtime }}
+bantime  = {{ traefik_fail2ban_bantime }}
+port     = http,https

--- a/playbooks/roles/traefik/templates/harp_dynamic.yml.j2
+++ b/playbooks/roles/traefik/templates/harp_dynamic.yml.j2
@@ -1,4 +1,10 @@
 http:
+{% if traefik_max_response_body_bytes | int > 0 %}
+  middlewares:
+    limit-response-body:
+      buffering:
+        maxResponseBodyBytes: {{ traefik_max_response_body_bytes }}
+{% endif %}
   serversTransports:
     exapps-transport:
       forwardingTimeouts:


### PR DESCRIPTION
Implement Fail2ban integration to improve security and monitoring within the Traefik setup. Update the Fail2ban exporter image and ensure consistency across configurations.