### PR TITLE
Bugfixes/nextclou ai

### DIFF
--- a/playbooks/roles/nextcloud/defaults/main.yml
+++ b/playbooks/roles/nextcloud/defaults/main.yml
@@ -82,7 +82,7 @@ nextcloud_exapp_list:
     # instead of the internal CPU-only llama.cpp model (~2 tok/s). The ExApp container is also
     # connected to ia_network (see tasks/main.yml) so it can resolve the 'ollama-embeddings' hostname.
     options: >-
-      --env CC_EM_BASE_URL=http://ollama-embeddings:11434
+      --env CC_EM_BASE_URL=http://ollama-embeddings:11434/v1
       --env CC_EM_MODEL_NAME=nomic-embed-text-v2-moe
   - name: context_agent # Context Agent integration for enhanced automation capabilities
     options: ""

--- a/playbooks/roles/nextcloud/defaults/main.yml
+++ b/playbooks/roles/nextcloud/defaults/main.yml
@@ -56,8 +56,9 @@ nextcloud_integration_openai_default_completion_model_id: "ministral-3:3b"
 nextcloud_integration_openai_request_timeout: 600
 nextcloud_integration_openai_max_tokens: 768
 nextcloud_context_chat_request_timeout: 900
-# bge-m3: 8192-token context window, multilingual (French-native), ideal for document indexing.
-nextcloud_context_chat_embedding_model: "bge-m3"
+# nomic-embed-text v1.5: 8192-token context, Q4 GGUF (stable, no NaN), works well for French.
+# bge-m3 F16 was tried but produces NaN values in Ollama for many document types.
+nextcloud_context_chat_embedding_model: "nomic-embed-text"
 
 nextcloud_context_agent_tool_status:
   mail: true
@@ -81,7 +82,7 @@ nextcloud_context_agent_tool_status:
 nextcloud_exapp_list:
   - name: context_chat_backend
     # CC_EM_BASE_URL delegates embeddings to the dedicated Ollama Embeddings instance.
-    # bge-m3: 8192-token context, multilingual — unlike nomic-embed-text-v2-moe (512 tokens, English-only).
+    # nomic-embed-text v1.5: 8192-token context, Q4 GGUF, stable (no NaN unlike bge-m3 F16).
     # The ExApp container is connected to ia_network (see tasks/main.yml) for hostname resolution.
     options: >-
       --env CC_EM_BASE_URL=http://ollama-embeddings:11434/v1

--- a/playbooks/roles/nextcloud/defaults/main.yml
+++ b/playbooks/roles/nextcloud/defaults/main.yml
@@ -56,6 +56,8 @@ nextcloud_integration_openai_default_completion_model_id: "ministral-3:3b"
 nextcloud_integration_openai_request_timeout: 600
 nextcloud_integration_openai_max_tokens: 768
 nextcloud_context_chat_request_timeout: 900
+# bge-m3: 8192-token context window, multilingual (French-native), ideal for document indexing.
+nextcloud_context_chat_embedding_model: "bge-m3"
 
 nextcloud_context_agent_tool_status:
   mail: true
@@ -78,12 +80,12 @@ nextcloud_context_agent_tool_status:
 
 nextcloud_exapp_list:
   - name: context_chat_backend
-    # CC_EM_BASE_URL delegates embeddings to the dedicated Ollama Embeddings instance (port 8082 proxy)
-    # instead of the internal CPU-only llama.cpp model (~2 tok/s). The ExApp container is also
-    # connected to ia_network (see tasks/main.yml) so it can resolve the 'ollama-embeddings' hostname.
+    # CC_EM_BASE_URL delegates embeddings to the dedicated Ollama Embeddings instance.
+    # bge-m3: 8192-token context, multilingual — unlike nomic-embed-text-v2-moe (512 tokens, English-only).
+    # The ExApp container is connected to ia_network (see tasks/main.yml) for hostname resolution.
     options: >-
       --env CC_EM_BASE_URL=http://ollama-embeddings:11434/v1
-      --env CC_EM_MODEL_NAME=nomic-embed-text-v2-moe
+      --env CC_EM_MODEL_NAME={{ nextcloud_context_chat_embedding_model }}
   - name: context_agent # Context Agent integration for enhanced automation capabilities
     options: ""
 

--- a/playbooks/roles/nextcloud/tasks/main.yml
+++ b/playbooks/roles/nextcloud/tasks/main.yml
@@ -255,6 +255,24 @@
   changed_when: volume_create.rc == 0
   failed_when: false
 
+# Ensure the embedding model is present before ExApp registration.
+# bge-m3 is pulled here (not in the ia role) since it is only needed by Nextcloud.
+# stream: false makes Ollama wait until the pull is fully complete before returning.
+- name: Pull context_chat embedding model into Ollama Embeddings instance
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:8082/api/pull"
+    method: POST
+    body_format: json
+    body:
+      name: "{{ nextcloud_context_chat_embedding_model }}"
+      stream: false
+    status_code: [200]
+    timeout: 600
+  register: nc_embedding_pull
+  until: nc_embedding_pull.status == 200
+  retries: 3
+  delay: 10
+
 - name: List registered ExApps
   ansible.builtin.command:
     cmd: 'docker exec --user www-data nc-nextcloud-1 php occ app_api:app:list'

--- a/playbooks/roles/nextcloud/templates/docker-compose.yml
+++ b/playbooks/roles/nextcloud/templates/docker-compose.yml
@@ -168,6 +168,10 @@ services:
       NC_INSTANCE_URL: "https://{{ app_domain_name }}"
       HP_FRP_DISABLE_TLS: "false"
       # HP_TRUSTED_PROXY_IPS: "127.0.0.1/32"
+      # HAProxy binds IPv4-only by default but the container has an IPv6 address on
+      # traefik_backend. PHP AppAPI (Guzzle) resolves 'harp' to IPv6 and gets
+      # "Connection refused". :::8780 listens on both IPv4 and IPv6.
+      HP_EXAPPS_ADDRESS: ":::8780"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:rw
       - harp-certs:/certs:rw


### PR DESCRIPTION
This pull request updates the Nextcloud integration to improve how embedding models are managed and used for context chat features. The main focus is on ensuring the correct embedding model (`nomic-embed-text`) is consistently configured, reliably pulled into the Ollama Embeddings instance, and properly referenced by the context chat backend. Additionally, a networking fix is applied to ensure ExApps are accessible over both IPv4 and IPv6.

**Embedding model improvements:**

* Set the default embedding model for context chat to `nomic-embed-text` in `main.yml`, with comments explaining the rationale and issues with alternative models.
* Updated ExApp backend configuration to use the embedding model variable and adjusted the embedding service base URL; improved documentation for embedding model selection and networking.
* Added an Ansible task to reliably pull the embedding model (`nomic-embed-text`) into the Ollama Embeddings instance before ExApp registration, ensuring the model is present and ready for use.

**Networking and configuration fixes:**

* Set the `HP_EXAPPS_ADDRESS` environment variable in the Docker Compose template to `:::8780` to ensure ExApps are reachable via both IPv4 and IPv6, preventing connection issues when the backend resolves to an IPv6 address.